### PR TITLE
Add new account hash value to the /stats page

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.26'
+def runeLiteVersion = '1.10.12'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/morghttpclient/HttpServerPlugin.java
+++ b/src/main/java/com/morghttpclient/HttpServerPlugin.java
@@ -131,6 +131,7 @@ public class HttpServerPlugin extends Plugin
 		JsonArray skills = new JsonArray();
 		JsonObject headers = new JsonObject();
 		headers.addProperty("username", client.getUsername());
+		headers.addProperty("account hash", client.getAccountHash());
 		headers.addProperty("player name", player.getName());
 		int skill_count = 0;
 		skills.add(headers);


### PR DESCRIPTION
Hi there!

client.getAccountHash() is the new account identifier that's supported by Jagex accounts and old style RuneScape character accounts. client.getUsername() is now deprecated and if a player logs in via a Jagex account then it just returns null now, so this is the new way to identify an account (even if the character username changes).

I'm happy to submit the pull request to the plugin-hub to update the plugin version if you'd like me to, just let me know :) 

Thanks