### PR TITLE
Fix after RL update 1.10.31.1

### DIFF
--- a/src/main/java/com/morghttpclient/HttpServerPlugin.java
+++ b/src/main/java/com/morghttpclient/HttpServerPlugin.java
@@ -235,9 +235,6 @@ public class HttpServerPlugin extends Plugin
 		camera.addProperty("x", client.getCameraX());
 		camera.addProperty("y", client.getCameraY());
 		camera.addProperty("z", client.getCameraZ());
-		// camera.addProperty("x2", client.getCameraX2());
-		// camera.addProperty("y2", client.getCameraY2());
-		// camera.addProperty("z2", client.getCameraZ2());
 		object.add("worldPoint", worldPoint);
 		object.add("camera", camera);
 		object.add("mouse", mouse);

--- a/src/main/java/com/morghttpclient/HttpServerPlugin.java
+++ b/src/main/java/com/morghttpclient/HttpServerPlugin.java
@@ -235,9 +235,9 @@ public class HttpServerPlugin extends Plugin
 		camera.addProperty("x", client.getCameraX());
 		camera.addProperty("y", client.getCameraY());
 		camera.addProperty("z", client.getCameraZ());
-		camera.addProperty("x2", client.getCameraX2());
-		camera.addProperty("y2", client.getCameraY2());
-		camera.addProperty("z2", client.getCameraZ2());
+		// camera.addProperty("x2", client.getCameraX2());
+		// camera.addProperty("y2", client.getCameraY2());
+		// camera.addProperty("z2", client.getCameraZ2());
 		object.add("worldPoint", worldPoint);
 		object.add("camera", camera);
 		object.add("mouse", mouse);

--- a/src/test/java/com/example/ExamplePluginTest.java
+++ b/src/test/java/com/example/ExamplePluginTest.java
@@ -1,5 +1,6 @@
 package com.example;
 
+import com.morghttpclient.HttpServerPlugin;
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
 
@@ -7,7 +8,7 @@ public class ExamplePluginTest
 {
 	public static void main(String[] args) throws Exception
 	{
-		ExternalPluginManager.loadBuiltin(ExamplePlugin.class);
+		ExternalPluginManager.loadBuiltin(HttpServerPlugin.class);
 		RuneLite.main(args);
 	}
 }


### PR DESCRIPTION
Camera position x2, y2 and z2 have been removed since RL 1.10.31.1, breaking the plugin. Removing these properties will fix the issue. 