### PR TITLE
Fix for RL 1.10.31.1 and various added features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,13 +10,13 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.26'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.20'
-	annotationProcessor 'org.projectlombok:lombok:1.18.20'
+	compileOnly 'org.projectlombok:lombok:1.18.30'
+	annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
 	testImplementation 'junit:junit:4.12'
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -24,9 +24,9 @@ dependencies {
 }
 
 group = 'com.morghttpclient'
-version = '1.8.26-SNAPSHOT'
-sourceCompatibility = '1.8'
+version = '1.0-SNAPSHOT'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+	options.release.set(11)
 }

--- a/src/main/java/com/morghttpclient/HttpServerConfig.java
+++ b/src/main/java/com/morghttpclient/HttpServerConfig.java
@@ -13,4 +13,11 @@ public interface HttpServerConfig extends Config
 	{
 		return 1200;
 	}
+
+	@ConfigItem(keyName = "Port", name = "Port", description = "Port to launch the webserver on")
+	@Range(min = 1, max = 20000)
+	default int port()
+	{
+		return 8081;
+	}
 }

--- a/src/main/java/com/morghttpclient/HttpServerPlugin.java
+++ b/src/main/java/com/morghttpclient/HttpServerPlugin.java
@@ -211,6 +211,8 @@ public class HttpServerPlugin extends Plugin
 		object.addProperty("Is idle", isIdle);
 		object.addProperty("latest msg", msg);
 		object.addProperty("run energy", client.getEnergy());
+		int specialAttack = client.getVarpValue(300) / 10;
+		object.addProperty("special attack", specialAttack);
 		object.addProperty("game tick", client.getGameCycle());
 		object.addProperty("health", client.getBoostedSkillLevel(Skill.HITPOINTS) + "/" + client.getRealSkillLevel(Skill.HITPOINTS));
 		object.addProperty("interacting code", String.valueOf(player.getInteracting()));

--- a/src/main/java/com/morghttpclient/HttpServerPlugin.java
+++ b/src/main/java/com/morghttpclient/HttpServerPlugin.java
@@ -75,10 +75,6 @@ public class HttpServerPlugin extends Plugin
 		server.start();
 		for (Skill skill : Skill.values())
 		{
-			if (skill == Skill.OVERALL)
-			{
-				continue;
-			}
 			xp_gained_skills[skill_count] = 0;
 			skill_count++;
 		}
@@ -106,10 +102,6 @@ public class HttpServerPlugin extends Plugin
 		int skill_count = 0;
 		for (Skill skill : Skill.values())
 		{
-			if (skill == Skill.OVERALL)
-			{
-				continue;
-			}
 			int xp_gained = handleTracker(skill);
 			xp_gained_skills[skill_count] = xp_gained;
 			skill_count ++;
@@ -136,10 +128,6 @@ public class HttpServerPlugin extends Plugin
 		skills.add(headers);
 		for (Skill skill : Skill.values())
 		{
-			if (skill == Skill.OVERALL)
-			{
-				continue;
-			}
 			JsonObject object = new JsonObject();
 			object.addProperty("stat", skill.getName());
 			object.addProperty("level", client.getRealSkillLevel(skill));

--- a/src/main/java/com/morghttpclient/HttpServerPlugin.java
+++ b/src/main/java/com/morghttpclient/HttpServerPlugin.java
@@ -235,9 +235,6 @@ public class HttpServerPlugin extends Plugin
 		camera.addProperty("x", client.getCameraX());
 		camera.addProperty("y", client.getCameraY());
 		camera.addProperty("z", client.getCameraZ());
-		camera.addProperty("x2", client.getCameraX2());
-		camera.addProperty("y2", client.getCameraY2());
-		camera.addProperty("z2", client.getCameraZ2());
 		object.add("worldPoint", worldPoint);
 		object.add("camera", camera);
 		object.add("mouse", mouse);

--- a/src/main/java/com/morghttpclient/HttpServerPlugin.java
+++ b/src/main/java/com/morghttpclient/HttpServerPlugin.java
@@ -63,7 +63,7 @@ public class HttpServerPlugin extends Plugin
 		//MAX_DISTANCE = config.reachedDistance();
 		skillList = Skill.values();
 		xpTracker = new XpTracker(this);
-		server = HttpServer.create(new InetSocketAddress(8081), 0);
+		server = HttpServer.create(new InetSocketAddress(config.port()), 0);
 		server.createContext("/stats", this::handleStats);
 		server.createContext("/inv", handlerForInv(InventoryID.INVENTORY));
 		server.createContext("/equip", handlerForInv(InventoryID.EQUIPMENT));

--- a/src/main/java/com/morghttpclient/HttpServerPlugin.java
+++ b/src/main/java/com/morghttpclient/HttpServerPlugin.java
@@ -68,7 +68,7 @@ public class HttpServerPlugin extends Plugin
 		server.createContext("/inv", handlerForInv(InventoryID.INVENTORY));
 		server.createContext("/equip", handlerForInv(InventoryID.EQUIPMENT));
 		server.createContext("/events", this::handleEvents);
-		server.setExecutor(Executors.newSingleThreadExecutor());
+		server.setExecutor(Executors.newCachedThreadPool());
 		startTime = System.currentTimeMillis();
 		xp_gained_skills = new int[Skill.values().length];
 		int skill_count = 0;

--- a/src/main/java/com/morghttpclient/HttpServerPlugin.java
+++ b/src/main/java/com/morghttpclient/HttpServerPlugin.java
@@ -11,6 +11,8 @@ import com.sun.net.httpserver.HttpServer;
 import java.io.*;
 import java.net.InetSocketAddress;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
@@ -24,6 +26,7 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.http.api.RuneLiteAPI;
+
 
 @PluginDescriptor(
 	name = "Morg HTTP Client",
@@ -196,12 +199,16 @@ public class HttpServerPlugin extends Plugin
 			npcHealth2 = 0;
 			health = 0;
 	}
+		final List<Integer> idlePoses = Arrays.asList(808, 813, 3418, 10075);
+
 		JsonObject object = new JsonObject();
 		JsonObject camera = new JsonObject();
 		JsonObject worldPoint = new JsonObject();
 		JsonObject mouse = new JsonObject();
 		object.addProperty("animation", player.getAnimation());
 		object.addProperty("animation pose", player.getPoseAnimation());
+		boolean isIdle = player.getAnimation() == -1 && idlePoses.contains(player.getPoseAnimation());
+		object.addProperty("Is idle", isIdle);
 		object.addProperty("latest msg", msg);
 		object.addProperty("run energy", client.getEnergy());
 		object.addProperty("game tick", client.getGameCycle());

--- a/src/test/java/com/example/ExamplePluginTest.java
+++ b/src/test/java/com/example/ExamplePluginTest.java
@@ -1,5 +1,6 @@
 package com.example;
 
+import com.morghttpclient.HttpServerPlugin;
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
 
@@ -7,7 +8,7 @@ public class ExamplePluginTest
 {
 	public static void main(String[] args) throws Exception
 	{
-		ExternalPluginManager.loadBuiltin(ExamplePlugin.class);
+		ExternalPluginManager.loadBuiltin(HttpServerPlugin.class);
 		RuneLite.main(args);
 	}
 }


### PR DESCRIPTION
I've fixed the plugin to work with the latest runelite version at this moment in time.

I've added a cached threadpool so you won't run into socket errors if you call the endpoint too often.

I've added a configurable port in case 8081 is already occupied.

I've added an idle bool to the events endpoint.

I've added special attack energy to the events endpoint.

I've updated the build file to use runelite.latest rather than a set version.

I've removed skill.overall from everything as it's deprecated.


If it turns out this project is still active i will add a lot more features